### PR TITLE
Add support for building Docker images for linux/arm64/v8

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -42,6 +42,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64/v8
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1


### PR DESCRIPTION
Add support for building Docker images for `linux/arm64/v8`.

* **GitHub Actions Workflow**:
  - Add `platforms: linux/amd64,linux/arm64/v8` to the `Build and push Docker image` step in `.github/workflows/release-image.yml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ahbanavi/goshneprro/pull/3?shareId=b34dee09-c133-4005-b0ee-6c23de63bfde).